### PR TITLE
fix: Restore modern GitHub Actions deployment method

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,38 +1,66 @@
-name: 🚀 Deploy to GitHub Pages (gh-pages method)
+name: 🚀 Deploy to GitHub Pages
 
 on:
   push:
     branches: ['main']
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
+  build:
+    name: 🔨 Build
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: 📦 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22.12.0'
           cache: 'npm'
-          
+
       - name: 📋 Install dependencies
         run: npm ci
-        
+
+      - name: 🔍 Lint code
+        run: npm run lint --if-present
+
       - name: 🏗️ Build application
         run: npm run build
-        
-      - name: 📁 Verify build output
+
+      - name: 📁 List build output
         run: |
-          echo "Build output:"
+          echo "Build output contents:"
           ls -la dist/
-          echo "index.html exists:"
-          test -f dist/index.html && echo "✅ index.html found" || echo "❌ index.html missing"
-        
-      - name: 🚀 Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+          echo "index.html contents:"
+          head -10 dist/index.html
+
+      - name: ⚙️ Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: 📤 Upload build artifacts
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          path: './dist'
+          retention-days: 1
+
+  deploy:
+    name: 🚀 Deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: 🌍 Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Replace peaceiris/actions-gh-pages with official GitHub Actions
- Use actions/configure-pages and actions/deploy-pages
- Add proper permissions and concurrency settings
- Include linting step in build process
- Better build verification and debugging